### PR TITLE
Remove one last sentence from 5.1 Fair Play

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -311,9 +311,6 @@ robots or the referee during normal game play.
 Programs are not allowed to cause interference to the field or to the ball during
 normal game play.
 
-{++A team that does that may be disqualified from the tournament at the OC's
-discretion.++}
-
 
 [[behavior]]
 === Behavior


### PR DESCRIPTION
The last sentence states that a team that violates the rules of fair play can be disqualified. But this is already mentioned in section 5.6 (Violations / Disqualification). I suggest the removal of this sentence from section 5.1.

